### PR TITLE
Extract entity creation

### DIFF
--- a/src/Test/FactoryTestCase.php
+++ b/src/Test/FactoryTestCase.php
@@ -56,8 +56,16 @@ abstract class FactoryTestCase extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->user    = fake($this->faker);
         $this->factory = new $this->class();
+        $this->createEntity();
+    }
+
+    /**
+     * Creates the test entity.
+     */
+    protected function createEntity(): void
+    {
+        $this->user = fake($this->faker);
     }
 
     public function testId()

--- a/tests/entities/MythEntityTest.php
+++ b/tests/entities/MythEntityTest.php
@@ -23,8 +23,8 @@ final class MythEntityTest extends EntityTestCase
     /**
      * Creates the scenario for entities that implement HasGroup
      * to verify the following checks:
-     *  - $this->entity->hasGroup('Dire') === false
-     *  - $this->entity->hasGroup('Radiant') === true
+     *  - $this->entity->hasGroup('dire') === false
+     *  - $this->entity->hasGroup('radiant') === true
      */
     protected function setUpGroups(HasGroup $entity): void
     {

--- a/tests/entities/ShieldEntityTest.php
+++ b/tests/entities/ShieldEntityTest.php
@@ -21,8 +21,8 @@ final class ShieldEntityTest extends EntityTestCase
     /**
      * Creates the scenario for entities that implement HasGroup
      * to verify the following checks:
-     *  - $this->entity->hasGroup('Dire') === false
-     *  - $this->entity->hasGroup('Radiant') === true
+     *  - $this->entity->hasGroup('dire') === false
+     *  - $this->entity->hasGroup('radiant') === true
      *
      * @param ShieldEntity $entity
      */


### PR DESCRIPTION
Moves entity creation during test to a separate method in order to facilitate extensions.